### PR TITLE
Adapt GOOPy to support Jacobian simulations

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,6 @@
-# Change these before your run the script.
+# See config_template.yaml for a description of the fields in this file
+
+# Local settings 
 LOCAL_SETTINGS:
   REPROCESS: 'True'
   SAVE_SATELLITE_DATA: 'True'
@@ -14,12 +16,30 @@ LOCAL_SETTINGS:
   FILE_LENGTH_THRESHOLD: 1.0e+6
 
 # Observations
+TCCON_MIP:
+  AVERAGING_KERNEL_USES_CENTERS_OR_EDGES: 'center'
+  PARSER: 'read_TCCON_MIP'
+  DATA_FIELDS:
+    N_OBS: 'n_obs_instr'
+    N_EDGES: 'n_lev'
+    N_CENTERS: 'none'
+    PRESSURE_EDGES: 'p_levels_ak'
+    PRESSURE_WEIGHT: 'none'
+    LATITUDE: 'latitude'
+    LONGITUDE: 'longitude'
+    TIME: 'cdate'
+    AVERAGING_KERNEL: 'avg_kernel'
+    PRIOR_PROFILE: 'prior_mixing' # This is already dry
+    SATELLITE_COLUMN: 'column_mixing'
+    QUALITY_FLAG: 'none'
+
 OCO2_v11.1_preprocessed:
   AVERAGING_KERNEL_USES_CENTERS_OR_EDGES: 'edges'
   PARSER: 'read_OCO2_v11_1_preprocessed'
   DATA_FIELDS:
     N_OBS: 'sounding_id'
     N_EDGES: 'levels'
+    N_CENTERS: 'none'
     PRESSURE_EDGES: 'pressure_levels'
     PRESSURE_WEIGHT: 'pressure_weight'
     LATITUDE: 'latitude'
@@ -34,32 +54,17 @@ TROPOMI:
   AVERAGING_KERNEL_USES_CENTERS_OR_EDGES: 'centers'
   PARSER: 'read_TROPOMI'
   DATA_FIELDS: 
-    N_OBS: 'nobs'
+    N_OBS: 'none'
     N_EDGES: 'none'
+    N_CENTERS: 'layer'
     PRESSURE_EDGES: 'none' 
-    PRESSURE_WEIGHT: 'dry_air_subcolumns'
-    LATITUDE: 'latitude_center'
-    LONGITUDE: 'longitude_center'
-    TIME: 'time'
-    AVERAGING_KERNEL: 'xch4_column_averaging_kernel'
-    PRIOR_PROFILE: 'ch4_profile_apriori'
-    SATELLITE_COLUMN: 'xch4'
-    QUALITY_FLAG: 'none'
-
-TROPOMI_blended: 
-  AVERAGING_KERNEL_USES_CENTERS_OR_EDGES: 'centers'
-  PARSER: 'read_TROPOMI_blended'
-  DATA_FIELDS: 
-    N_OBS: 'nobs'
-    N_EDGES: 'none'        # These variables do not exist and are  
-    PRESSURE_EDGES: 'none' # created in the parser
-    PRESSURE_WEIGHT: 'dry_air_subcolumns'
+    PRESSURE_WEIGHT: 'none'
     LATITUDE: 'latitude'
     LONGITUDE: 'longitude'
     TIME: 'time_utc'
     AVERAGING_KERNEL: 'column_averaging_kernel'
     PRIOR_PROFILE: 'methane_profile_apriori'
-    SATELLITE_COLUMN: 'methane_mixing_ratio_blended'
+    SATELLITE_COLUMN: 'methane_mixing_ratio_bias_corrected'
     QUALITY_FLAG: 'qa_value'
 
 GOSATv9_0:
@@ -68,6 +73,7 @@ GOSATv9_0:
   DATA_FIELDS:
     N_OBS: 'n'
     N_EDGES: 'm'
+    N_CENTERS: 'none'
     PRESSURE_EDGES: 'pressure_levels'
     PRESSURE_WEIGHT: 'pressure_weight'
     LATITUDE: 'latitude'
@@ -81,8 +87,8 @@ GOSATv9_0:
 # Model
 MODEL:
   DATA_FIELDS:
-    PRESSURE_EDGES: 'Met_PEDGE' # Not PEDGEDRY?
-    CONC_AT_PRESSURE_CENTERS: 'SpeciesConcVV_.*' # todo: CO2 vs CH4. 
+    PRESSURE_EDGES: 'Met_PEDGE'
+    CONC_AT_PRESSURE_CENTERS: 'SpeciesConcVV_.*'
     LATITUDE: 'lat'
     LONGITUDE: 'lon'
     TIME: 'time'

--- a/config.yaml
+++ b/config.yaml
@@ -29,7 +29,7 @@ TCCON_MIP:
     LONGITUDE: 'longitude'
     TIME: 'cdate'
     AVERAGING_KERNEL: 'avg_kernel'
-    PRIOR_PROFILE: 'prior_mixing' # This is already dry
+    PRIOR_PROFILE: 'prior_mixing'
     SATELLITE_COLUMN: 'column_mixing'
     QUALITY_FLAG: 'none'
 

--- a/config.yaml
+++ b/config.yaml
@@ -2,13 +2,15 @@
 LOCAL_SETTINGS:
   REPROCESS: 'True'
   SAVE_SATELLITE_DATA: 'True'
-  SATELLITE_NAME: 'OCO2_v11.1_preprocessed'
-  OBS_DIR: '/nobackupp27/hnesser/CO2_inversion/observations/OCO-2'
-  OBS_FILE_FORMAT: 'oco2_20141*.nc'
-  MODEL_DIR: '/nobackupp27/hnesser/CO2_inversion/validation_dirs/gc_4x5_47L_merra2_CO2/OutputDir'
+  SAVE_INTERPOLATION: 'True'
+  SATELLITE_NAME: satellitesatellite
+  OBS_DIR: obsdirobsdir
+  OBS_FILE_FORMAT: filefile
+  MODEL_LEVEL_EDGE_DIR: priordirpriordir
   LEVEL_EDGE_FILE_FORMAT: 'GEOSChem.LevelEdgeDiags.*.nc4' 
+  MODEL_CONCENTRATION_DIR: moddirmoddir
   CONCENTRATION_FILE_FORMAT: 'GEOSChem.SpeciesConc.*.nc4' 
-  SAVE_DIR: '/nobackupp27/hnesser/CO2_inversion/validation_dirs/gc_4x5_47L_merra2_CO2/ProcessedDir'
+  SAVE_DIR: savedirsavedir
   FILE_LENGTH_THRESHOLD: 1.0e+6
 
 # Observations
@@ -25,7 +27,7 @@ OCO2_v11.1_preprocessed:
     TIME: 'time'
     AVERAGING_KERNEL: 'xco2_averaging_kernel'
     PRIOR_PROFILE: 'co2_profile_apriori'
-    SATELLITE_COLUMN: 'xco2'
+    SATELLITE_COLUMN: 'xco2_x2019'
     QUALITY_FLAG: 'none'
 
 TROPOMIvXX: # version is specified for each instrument
@@ -69,7 +71,7 @@ GOSATv9_0:
 MODEL:
   DATA_FIELDS:
     PRESSURE_EDGES: 'Met_PEDGE' # Not PEDGEDRY?
-    CONC_AT_PRESSURE_CENTERS: 'SpeciesConcVV_CO2' # todo: CO2 vs CH4. 
+    CONC_AT_PRESSURE_CENTERS: 'SpeciesConcVV_.*' # todo: CO2 vs CH4. 
     LATITUDE: 'lat'
     LONGITUDE: 'lon'
     TIME: 'time'

--- a/config.yaml
+++ b/config.yaml
@@ -30,18 +30,13 @@ OCO2_v11.1_preprocessed:
     SATELLITE_COLUMN: 'xco2_x2019'
     QUALITY_FLAG: 'none'
 
-TROPOMIvXX: # version is specified for each instrument
+TROPOMI: 
   AVERAGING_KERNEL_USES_CENTERS_OR_EDGES: 'centers'
-  PARSER: 'read_TROPOMIvXX'
+  PARSER: 'read_TROPOMI'
   DATA_FIELDS: 
     N_OBS: 'nobs'
-    N_EDGES: 'nlevels'
-    PRESSURE_EDGES: 'pressure_edges' # This variable does not
-    # exist in the TROPOMI files and needs to be created in the
-    # parser.
-    # N_CENTERS: 'nlayers'
-    # SURFACE_PRESSURE: 'surface_pressure'
-    # DELTA_PRESSURE: 'dp' 
+    N_EDGES: 'none'
+    PRESSURE_EDGES: 'none' 
     PRESSURE_WEIGHT: 'dry_air_subcolumns'
     LATITUDE: 'latitude_center'
     LONGITUDE: 'longitude_center'
@@ -50,6 +45,22 @@ TROPOMIvXX: # version is specified for each instrument
     PRIOR_PROFILE: 'ch4_profile_apriori'
     SATELLITE_COLUMN: 'xch4'
     QUALITY_FLAG: 'none'
+
+TROPOMI_blended: 
+  AVERAGING_KERNEL_USES_CENTERS_OR_EDGES: 'centers'
+  PARSER: 'read_TROPOMI_blended'
+  DATA_FIELDS: 
+    N_OBS: 'nobs'
+    N_EDGES: 'none'        # These variables do not exist and are  
+    PRESSURE_EDGES: 'none' # created in the parser
+    PRESSURE_WEIGHT: 'dry_air_subcolumns'
+    LATITUDE: 'latitude'
+    LONGITUDE: 'longitude'
+    TIME: 'time_utc'
+    AVERAGING_KERNEL: 'column_averaging_kernel'
+    PRIOR_PROFILE: 'methane_profile_apriori'
+    SATELLITE_COLUMN: 'methane_mixing_ratio_blended'
+    QUALITY_FLAG: 'qa_value'
 
 GOSATv9_0:
   AVERAGING_KERNEL_USES_CENTERS_OR_EDGES: 'edges'

--- a/config_template.yaml
+++ b/config_template.yaml
@@ -1,21 +1,136 @@
-# Generic config format for a satellite that specifies the 
-# vertical grid using pressure edges.
-SATELLITE_USING_PRESSURE_EDGES:
+# This file provides a detailed description of the variables in the config 
+# file.  The config file is arranged into three main sections:
+# 1. LOCAL_SETTINGS: This contains general settings related to GOOPy as well
+#                    as file paths and naming conventions for the satellite 
+#                    and model data.
+# 2. Observations: Each observation block corresponds to a specific satellite 
+#                  or ground-based column-observing instrument (e.g., TCCON).
+#                  These blocks provide information on the structure of the
+#                  satellite data files and generally do not need to be modified 
+#                  once they've been created.
+# 3. MODEL: This block describes the structure of the GEOS-Chem output files. 
+#           As with the Observation blocks, this generally does not need to be
+#           modified once created.       
+
+# Note: All file paths can be specified as absolute or relative to the 
+# directory where GOOPy is being run [TODO: confirm this behavior].
+
+LOCAL_SETTINGS: 
   REPROCESS: 'True' or 'False'
+  # Default: 'True'
+  # Reprocess determines whether or not to re-process satellite files for which
+  # a processed file with the observation operator applied already exists in 
+  # the save directory.
+
   SAVE_SATELLITE_DATA: 'True' or 'False'
+  # Default: 'True'
+  # This flag controls whether or not to save  original satellite data, 
+  # including any supplemental variables (e.g., blended albedo). If 'False',
+  # only the model columns get saved out, which is particularly useful for
+  # Jacobian simulations. TODO: Check the behavior of False to confirm this.
+
+  SAVE_INTERPOLATION: 'True' or 'False'
+  # Default: 'False'
+  # This flag controls whether to save out arrays that map from the model grid
+  # to the satellite grid in the lat, lon, time, and pressure dimensions. These
+  # are saved in a <OBS_DIR>/operator_components. This will primarily be set
+  # to 'True' for Jacobian simulations.
+
+  SATELLITE_NAME: <Name of satellite>
+  # This is the name of the satellite, which should correspond to the the name
+  # used lower in the config file under the observation block.
+
+  OBS_DIR: <path/to/satellite/data/directory>
+  # Path to the satellite (or TCCON) observations.
+
+  OBS_FILE_FORMAT: <String pattern for satellite data files, e.g. 'file_*.nc4'>
+  # This is the string pattern used to identify satellite data files within 
+  # OBS_DIR. It should be capable of regex since it is used within glob. 
+
+  MODEL_LEVEL_EDGE_DIR: <path/to/model/level/edge/directory>
+  # Path to the directory containing GEOS-Chem LevelEdgeDiags output files. This
+  # is specfied separately from the MODEL_CONCENTRATION_DIR (below) to support
+  # Jacobian simulations (where the LevelEdgeDiag files are typically generated
+  # only once in the prior simulation).
+
+  LEVEL_EDGE_FILE_FORMAT: <String pattern, e.g. 'GEOSChem.LevelEdgeDiags.*.nc4'>
+  # String pattern used to identify LevelEdgeDiags files within 
+  # MODEL_LEVEL_EDGE_DIR. It should be capable of regex.
+
+  MODEL_CONCENTRATION_DIR: <path/to/model/concentration/directory>
+  # Path to the directory containing GEOS-Chem SpeciesConc output files.
+
+  CONCENTRATION_FILE_FORMAT: <String pattern, e.g. 'GEOSChem.SpeciesConc.*.nc4'>
+  # String pattern used to identify SpeciesConc files within 
+  # MODEL_CONCENTRATION_DIR. It should be capable of regex.
+
+  SAVE_DIR: <path/to/output/directory>
+  # Directory where processed output files will be saved. Can be absolute or
+  # relative.
+
+  FILE_LENGTH_THRESHOLD: <numeric value, e.g. 1.0e+6>
+  # The number of individual observations to process at a time. This can be 
+  # changed to reflect the available memory
+
+# Observations
+<SATELLITE_NAME>: 
+# Each observation type has its own block. The name of the block should 
+# correspond to the name specified in LOCAL_SETTINGS for SATELLITE_NAME.
+# Each block contains the following values:
+
   AVERAGING_KERNEL_USES_CENTERS_OR_EDGES: 'centers' or 'edges'
-  OBS_DIR: 'location_of_data'
-  FILE_NAME_FORMAT: 'file_name_format*.nc'
-  PARSER: 'parser_name_in_parsers.py'
+  # Whether the averaging kernel (and prior_profile and satellite_column) are 
+  #defined on pressure layer centers or edges.
+
+  PARSER: <function name>
+  # The name of the function within parsers.py used to read each file for the 
+  # instrument to generate an xarray dataset that has any of the relevant 
+  # coordinates and all of the variables within DATA_FIELDS (below). A generic 
+  # parser is available if there is a one-to-one mapping between the 
+  # DATA_FIELDS and the satellite variables. However, users should still be 
+  # careful to ensure that any pressure units are hPa. 
+
   DATA_FIELDS:
-    N_OBS: 'observation_dimension_name'
-    N_EDGES: 'vertical_level_edges_dimension_name'  # What is the difference between
-    PRESSURE_EDGES: 'variable_name' # these two fields?
-    PRESSURE_WEIGHT: 'variable_name'
-    LATITUDE: 'variable_name'
-    LONGITUDE: 'variable_name'
-    TIME: 'variable_name'
-    AVERAGING_KERNEL: 'variable_name'
-    PRIOR_PROFILE: 'variable_name'
-    SATELLITE_COLUMN: 'variable_name'
-    QUALITY_FLAG: 'optional_variable_name_or_none'
+  # A mapping from generic internal field names to the actual variable names
+  # in the instrument's data files. Use 'none' if a field is not present or
+  # needs to be generated by the parser.
+
+    # Coordinates:
+    N_OBS:            <String for the observation dimension>
+    N_EDGES:          <String for the pressure edge level dimension>
+    N_CENTERS:        <String for the pressure center levels dimension>
+    # N_CENTERS is only defined as something other than 'none' if 
+    # AVERAGING_KERNEL_USES_CENTERS_OR_EDGES is 'center'.
+
+    # Variables
+    PRESSURE_EDGES:   <String for the pressure edge values>
+    PRESSURE_WEIGHT:  <String for pressure weights used to add together the
+                       sub-column concentrations>
+    LATITUDE:         <String for the latitude variable>
+    LONGITUDE:        <String for the longitude variable>
+    TIME:             <String for the time variable, which should have a 
+                       np.datetime64 format [TODO: confirm]>
+    AVERAGING_KERNEL: <String for the column averaging kernel>
+    PRIOR_PROFILE:    <String for the prior (a priori) vertical profile, which
+                       should have units of hPa>
+    SATELLITE_COLUMN: <String for the satellite or instrument measured 
+                       concentration>
+    QUALITY_FLAG:     <Optional string used to filter low-quality retrievals. 
+                       [TODO: No filtering is currently implemented]>
+
+MODEL:
+  DATA_FIELDS:
+    PRESSURE_EDGES: 'Met_PEDGE'
+    # Variable containing model pressure edge values (in hPa), from the
+    # LevelEdgeDiags output.
+
+    CONC_AT_PRESSURE_CENTERS: 'SpeciesConcVV_.*'
+    # Regex pattern matching the species concentration variable(s) in the
+    # SpeciesConc output. The .* allows matching any species name for Jacobian
+    # simulations that use multiple tracers.
+
+    LATITUDE: 'lat'
+    LONGITUDE: 'lon'
+    TIME: 'time'
+    LEV: 'lev'
+    ILEV: 'ilev'

--- a/interpolation.py
+++ b/interpolation.py
@@ -1,5 +1,12 @@
-import numpy as np
+import os
 
+os.environ['OPENBLAS_NUM_THREADS'] = '8'
+os.environ['MPI_NUM_THREADS'] = '8'
+os.environ['MKL_NUM_THREADS'] = '8'
+os.environ['OMP_NUM_THREADS'] = '8'
+
+import numpy as np
+import time
 
 class VerticalGrid:
     """
@@ -20,13 +27,19 @@ class VerticalGrid:
         model_edges,
         satellite_edges,
         interpolate_to_centers_or_edges,
+        save_interpolation,
+        save_dir
     ):
         self.model_conc_at_layers = model_conc_at_layers
         self.model_edges = model_edges
         self.satellite_edges = satellite_edges
         self.interpolate_to_centers_or_edges = interpolate_to_centers_or_edges
+        self.save_interpolation = save_interpolation
+        self.save_dir = save_dir
 
+        print('Expanding profile dims : ', time.time())
         self.__expand_profile_dims()
+        print('Checking input structure : ', time.time())
         self.__check_input_structure()
 
         self.n_obs = self.model_conc_at_layers.shape[0]
@@ -49,14 +62,14 @@ class VerticalGrid:
 
     def __check_input_structure(self):
         assert (
-            self.model_conc_at_layers.ndim == 2
-        ), "GEOS-Chem methane layers must be 2D (nobs x nlevels), or 1D (nlevels)."
+            self.model_conc_at_layers.ndim >= 2
+        ), "GEOS-Chem methane layers must be 2D (nobs x nlevels) or 3D (nobs x nlevels x nspecies)."
         assert (
             self.model_edges.ndim == 2
-        ), "GEOS-Chem pressure edges must be 2D (nobs x nlevels), or 1D (nlevels)."
+        ), "GEOS-Chem pressure edges must be 2D (nobs x nlevels)."
         assert (
             self.satellite_edges.ndim == 2
-        ), "Satellite pressure edges must be 2D (nobs x nlevels), or 1D (nlevels)."
+        ), "Satellite pressure edges must be 2D (nobs x nlevels)."
 
         assert np.all(
             np.diff(self.model_edges) < 0
@@ -143,35 +156,58 @@ class VerticalGrid:
 
     def interpolate(self):
         """
-        Interpolate GEOS-Chem methane to satellite edges OR centers.
+        Interpolate GEOS-Chem methane to satellite edges OR centers. Use
+        a pre-calculating interpolation_map if available--this is to optimize 
+        Jacobian construction.
         """
         expanded_model_edges = self.expand_model_to_satellite_range()
 
-        if self.interpolate_to_centers_or_edges == "centers":
-            interpolation_map = self.get_interpolation_map(
-                model_edges=expanded_model_edges, satellite_edges=self.satellite_edges
-            )
-            partial_column_to_conc = 1 / np.abs(np.diff(self.satellite_edges))  # M_out*
-
-        elif self.interpolate_to_centers_or_edges == "edges":
+        if self.interpolate_to_centers_or_edges == "edges":
             hprime_satellite_edges = self.get_hprime_satellite_edges()
-            interpolation_map = self.get_interpolation_map(
-                model_edges=expanded_model_edges, satellite_edges=hprime_satellite_edges
-            )  # interpolates model to hprime satellite layers
-            partial_column_to_conc = 1 / np.abs(
-                np.diff(hprime_satellite_edges)
-            )  # M_out*
 
-        else:
-            raise ValueError(
-                f"interpolate_to_centers_or_edges must be 'centers' or 'edges', not {self.interpolate_to_centers_or_edges}"
-            )
+        # Get the interpolation map
+        try:
+            print('Load interpolation : ', time.time())
+            interpolation_map = np.load(f"{self.save_dir}_interpolation.npy")
+            print("  Using pre-computed interpolation map.")
+        except:
+            print("  Computing interpolation map.")
+            print('Compute interpolation : ', time.time())
+            if self.interpolate_to_centers_or_edges == "centers":
+                interpolation_map = self.get_interpolation_map(
+                    model_edges=expanded_model_edges, 
+                    satellite_edges=self.satellite_edges
+                )
+            elif self.interpolate_to_centers_or_edges == "edges":
+                interpolation_map = self.get_interpolation_map(
+                    model_edges=expanded_model_edges, 
+                    satellite_edges=hprime_satellite_edges
+                )  # interpolates model to hprime satellite layers
+            else:
+                raise ValueError(
+                    f"interpolate_to_centers_or_edges must be 'centers' or 'edges',"
+                    f" not {self.interpolate_to_centers_or_edges}"
+                )
+            
+            # Save out the interpolation map
+            if self.save_interpolation.lower() == "true":
+                np.save(f"{self.save_dir}_interpolation.npy", interpolation_map)
 
+        print('Get partial column : ', time.time())
+        # Get the partial column in concentration space? # M_out*
+        if self.interpolate_to_centers_or_edges == "centers":
+            partial_column_to_conc = 1 / np.abs(np.diff(self.satellite_edges))
+        elif self.interpolate_to_centers_or_edges == "edges":
+            partial_column_to_conc = 1 / np.abs(np.diff(hprime_satellite_edges))
+
+        # Calculate the satellite partial column
+        print('Calculate satellite partial column : ', time.time())
         satellite_partial_columns = (
-            interpolation_map * self.model_conc_at_layers[:, :, None]
-        ).sum(
-            axis=1
-        )  # matrix multiplication across nobs model concentration vectors
-        satellite_conc = partial_column_to_conc * satellite_partial_columns
+            interpolation_map[:, :, :, None] * 
+            self.model_conc_at_layers[:, :, None, :]
+        ).sum(axis=1)  # matrix multiplication across nobs model vectors
+        print('Step 2 : ', time.time())
+        satellite_conc = (partial_column_to_conc[:, :, None] * 
+                          satellite_partial_columns)
 
         return satellite_conc

--- a/interpolation.py
+++ b/interpolation.py
@@ -1,10 +1,4 @@
 import os
-
-os.environ['OPENBLAS_NUM_THREADS'] = '8'
-os.environ['MPI_NUM_THREADS'] = '8'
-os.environ['MKL_NUM_THREADS'] = '8'
-os.environ['OMP_NUM_THREADS'] = '8'
-
 import numpy as np
 
 class VerticalGrid:

--- a/interpolation.py
+++ b/interpolation.py
@@ -6,7 +6,6 @@ os.environ['MKL_NUM_THREADS'] = '8'
 os.environ['OMP_NUM_THREADS'] = '8'
 
 import numpy as np
-import time
 
 class VerticalGrid:
     """
@@ -37,9 +36,7 @@ class VerticalGrid:
         self.save_interpolation = save_interpolation
         self.save_dir = save_dir
 
-        print('Expanding profile dims : ', time.time())
         self.__expand_profile_dims()
-        print('Checking input structure : ', time.time())
         self.__check_input_structure()
 
         self.n_obs = self.model_conc_at_layers.shape[0]
@@ -167,12 +164,10 @@ class VerticalGrid:
 
         # Get the interpolation map
         try:
-            print('Load interpolation : ', time.time())
             interpolation_map = np.load(f"{self.save_dir}_interpolation.npy")
             print("  Using pre-computed interpolation map.")
         except:
             print("  Computing interpolation map.")
-            print('Compute interpolation : ', time.time())
             if self.interpolate_to_centers_or_edges == "centers":
                 interpolation_map = self.get_interpolation_map(
                     model_edges=expanded_model_edges, 
@@ -193,7 +188,6 @@ class VerticalGrid:
             if self.save_interpolation.lower() == "true":
                 np.save(f"{self.save_dir}_interpolation.npy", interpolation_map)
 
-        print('Get partial column : ', time.time())
         # Get the partial column in concentration space? # M_out*
         if self.interpolate_to_centers_or_edges == "centers":
             partial_column_to_conc = 1 / np.abs(np.diff(self.satellite_edges))
@@ -201,12 +195,10 @@ class VerticalGrid:
             partial_column_to_conc = 1 / np.abs(np.diff(hprime_satellite_edges))
 
         # Calculate the satellite partial column
-        print('Calculate satellite partial column : ', time.time())
         satellite_partial_columns = (
             interpolation_map[:, :, :, None] * 
             self.model_conc_at_layers[:, :, None, :]
         ).sum(axis=1)  # matrix multiplication across nobs model vectors
-        print('Step 2 : ', time.time())
         satellite_conc = (partial_column_to_conc[:, :, None] * 
                           satellite_partial_columns)
 

--- a/interpolation.py
+++ b/interpolation.py
@@ -27,7 +27,8 @@ class VerticalGrid:
         satellite_edges,
         interpolate_to_centers_or_edges,
         save_interpolation,
-        save_dir
+        save_dir,
+        expand_model_edges=True
     ):
         self.model_conc_at_layers = model_conc_at_layers
         self.model_edges = model_edges
@@ -35,6 +36,10 @@ class VerticalGrid:
         self.interpolate_to_centers_or_edges = interpolate_to_centers_or_edges
         self.save_interpolation = save_interpolation
         self.save_dir = save_dir
+        self.expand_model_edges = expand_model_edges 
+        # NOTE: This should always be True. We set it as a variable because
+        # we use this class to do some additional interpolation for the TCCON
+        # parser, and it requires some flexibility in this assumption
 
         self.__expand_profile_dims()
         self.__check_input_structure()
@@ -68,11 +73,15 @@ class VerticalGrid:
             self.satellite_edges.ndim == 2
         ), "Satellite pressure edges must be 2D (nobs x nlevels)."
 
+        # The less than or equal to allows for the TCCON processing where
+        # some observations have multiple pressure levels with 0 pressure
+        # at the top of the atmosphere (to fill in variability in the 
+        # number of active layers).
         assert np.all(
-            np.diff(self.model_edges) < 0
+            np.diff(self.model_edges) <= 0
         ), "GEOS-Chem pressure levels must be in descending order."
         assert np.all(
-            np.diff(self.satellite_edges) < 0
+            np.diff(self.satellite_edges) <= 0
         ), "Satellite pressure levels must be in descending order."
 
         assert (
@@ -97,8 +106,10 @@ class VerticalGrid:
         top is below the satellite top. We do this by adjusting the
         GEOS-Chem surface pressure up to the satellite surface pressure
         """
-        idx_bottom = np.less(self.model_edges[:, 0], self.satellite_edges[:, 0])
-        idx_top = np.greater(self.model_edges[:, -1], self.satellite_edges[:, -1])
+        idx_bottom = np.less(self.model_edges[:, 0], 
+                             self.satellite_edges[:, 0])
+        idx_top = np.greater(self.model_edges[:, -1], 
+                             self.satellite_edges[:, -1])
 
         expanded_model_edges = self.model_edges.copy()
         expanded_model_edges[idx_bottom, 0] = self.satellite_edges[idx_bottom, 0]
@@ -114,7 +125,6 @@ class VerticalGrid:
         interpolation_map is equivalent to W * M_in in Keppens et al. (2019) eq. 14,
         and has dimension (nobs x ngc x nsat)
         """
-
         # Define matrices with "low" and "high" pressure values for each layer.
         # shape: nobs x n_model_levels - 1 x n_satellite_levels - 1
         model_low = model_edges[:, 1:][:, :, None]
@@ -123,9 +133,8 @@ class VerticalGrid:
         satellite_low = satellite_edges[:, 1:][:, None, :]
         satellite_high = satellite_edges[:, :-1][:, None, :]
 
-        interpolation_map = np.minimum(satellite_high, model_high) - np.maximum(
-            satellite_low, model_low
-        )
+        interpolation_map = (np.minimum(satellite_high, model_high) - 
+                             np.maximum(satellite_low, model_low))
         layers_do_not_intersect = ~(
             np.less_equal(satellite_low, model_high)
             & np.greater_equal(satellite_high, model_low)
@@ -157,7 +166,10 @@ class VerticalGrid:
         a pre-calculating interpolation_map if available--this is to optimize 
         Jacobian construction.
         """
-        expanded_model_edges = self.expand_model_to_satellite_range()
+        if self.expand_model_edges:
+            expanded_model_edges = self.expand_model_to_satellite_range()
+        else:
+            expanded_model_edges = self.model_edges
 
         if self.interpolate_to_centers_or_edges == "edges":
             hprime_satellite_edges = self.get_hprime_satellite_edges()

--- a/main.py
+++ b/main.py
@@ -1,4 +1,10 @@
 import os
+
+os.environ['OPENBLAS_NUM_THREADS'] = '8'
+os.environ['MPI_NUM_THREADS'] = '8'
+os.environ['MKL_NUM_THREADS'] = '8'
+os.environ['OMP_NUM_THREADS'] = '8'
+
 import yaml
 import numpy as np
 import xarray as xr
@@ -17,7 +23,7 @@ def apply_operator_to_chunks(model_conc_files,
     i = 0
     model_columns = []
     satellite_columns = []
-    while i < satellite.dims["N_OBS"]:
+    while i < satellite.sizes["N_OBS"]:
         # Subset the satellite data
         sat_i = satellite.isel(
             N_OBS=slice(
@@ -25,7 +31,7 @@ def apply_operator_to_chunks(model_conc_files,
                 int(i + config["LOCAL_SETTINGS"]["FILE_LENGTH_THRESHOLD"])
             )
         )
-    
+
         # Get the dates that need to be processed
         process_dates = np.unique(sat_i["TIME"].dt.strftime("%Y-%m-%d"))
 
@@ -34,6 +40,7 @@ def apply_operator_to_chunks(model_conc_files,
             util.get_gc_files_for_dates(model_conc_files, process_dates),
             util.get_gc_files_for_dates(model_edge_files, process_dates),
             config["MODEL"]["DATA_FIELDS"])
+        mod_i = mod_i.compute()
 
         # Check for times that are missing in the satellite data and continue
         # if there are no overlapping itmes
@@ -45,14 +52,22 @@ def apply_operator_to_chunks(model_conc_files,
             continue
 
         # Run the column operator
+        satellite_name = config["LOCAL_SETTINGS"]["SATELLITE_NAME"]
         model_columns.append(
             operators.get_model_columns(
-                mod_i, sat_i.where(~missing_times, drop=True), 
-                config["LOCAL_SETTINGS"]["SATELLITE_NAME"]))
+                mod_i, sat_i.where(~missing_times, drop=True),
+                config[satellite_name]["AVERAGING_KERNEL_USES_CENTERS_OR_EDGES"],
+                config["LOCAL_SETTINGS"]["SAVE_INTERPOLATION"],
+                f'{config["LOCAL_SETTINGS"]["OBS_DIR"]}/'
+                'operator_components/'
+                f'{process_dates.min()}_{process_dates.max()}_{int(i):04d}'
+                )
+            )
         if config["LOCAL_SETTINGS"]["SAVE_SATELLITE_DATA"].lower() == "true":
             satellite_columns.append(
-                sat_i.drop(['PRESSURE_EDGES', 'PRESSURE_WEIGHT',
-                            'AVERAGING_KERNEL', 'PRIOR_PROFILE', 'N_EDGES']))
+                sat_i.drop_vars(['PRESSURE_EDGES', 'PRESSURE_WEIGHT',
+                                 'AVERAGING_KERNEL', 'PRIOR_PROFILE',
+                                 'N_EDGES']))
 
         # Step up i
         i += config["LOCAL_SETTINGS"]["FILE_LENGTH_THRESHOLD"]
@@ -60,7 +75,9 @@ def apply_operator_to_chunks(model_conc_files,
     # Concatenate together, combine, and return
     if len(model_columns) > 0:
         model_columns = xr.concat(model_columns, dim="N_OBS")
-        model_columns = model_columns.rename("MODEL_COLUMN")
+        rename = {v : v.replace('CONC_AT_PRESSURE_CENTERS', 'MODEL_COLUMN')
+                  for v in model_columns.data_vars}
+        model_columns = model_columns.rename(rename)
         if config["LOCAL_SETTINGS"]["SAVE_SATELLITE_DATA"].lower() == "true":
             satellite_columns = xr.concat(satellite_columns, dim="N_OBS")
             model_columns = xr.merge([model_columns, satellite_columns])
@@ -75,6 +92,13 @@ def apply_operator(config):#satellite_name, file_length_threshold=1e6):
     # Make save out directory
     if not os.path.exists(config["LOCAL_SETTINGS"]["SAVE_DIR"]):
         os.makedirs(config["LOCAL_SETTINGS"]["SAVE_DIR"])
+
+    # Also make a directory to save out the components of the operator (e.g.,
+    # space and time indices and the interpolation map) if needed.
+    if config["LOCAL_SETTINGS"]["SAVE_INTERPOLATION"]:
+        save_dir = f'{config["LOCAL_SETTINGS"]["OBS_DIR"]}/operator_components'
+        if not os.path.exists(save_dir):
+            os.makedirs(save_dir)
 
     # Obtain a list of the satellite and GEOS-Chem files.
     files = util.get_file_lists(config["LOCAL_SETTINGS"])
@@ -114,6 +138,7 @@ def apply_operator(config):#satellite_name, file_length_threshold=1e6):
         satellite = satellite.where(
             satellite["TIME"].dt.strftime("%Y-%m-%d").isin(satellite_dates), 
             drop=True)
+        satellite = satellite.compute()
 
         # Next, apply the operator
         model_columns = apply_operator_to_chunks(

--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ def apply_operator_to_chunks(model_conc_files,
         mod_i = mod_i.compute()
 
         # Check for times that are missing in the satellite data and continue
-        # if there are no overlapping itmes
+        # if there are no overlapping times.
         missing_times = util.get_missing_times(sat_i["TIME"], mod_i["TIME"])
         if (~missing_times).sum() == 0:
             print("  There are no overlapping satellite and model data in"
@@ -52,22 +52,23 @@ def apply_operator_to_chunks(model_conc_files,
             continue
 
         # Run the column operator
-        satellite_name = config["LOCAL_SETTINGS"]["SATELLITE_NAME"]
+        save_dir = (
+            f'{config["LOCAL_SETTINGS"]["OBS_DIR"]}/operator_components/'
+            f'{process_dates.min()}_{process_dates.max()}_{int(i):04d}'
+        )
         model_columns.append(
             operators.get_model_columns(
-                mod_i, sat_i.where(~missing_times, drop=True),
-                config[satellite_name]["AVERAGING_KERNEL_USES_CENTERS_OR_EDGES"],
-                config["LOCAL_SETTINGS"]["SAVE_INTERPOLATION"],
-                f'{config["LOCAL_SETTINGS"]["OBS_DIR"]}/'
-                'operator_components/'
-                f'{process_dates.min()}_{process_dates.max()}_{int(i):04d}'
-                )
+                mod_i, sat_i.where(~missing_times, drop=True), config, save_dir
             )
+        )
         if config["LOCAL_SETTINGS"]["SAVE_SATELLITE_DATA"].lower() == "true":
+            drop_vars = ["PRESSURE_EDGES", "PRESSURE_WEIGHT",
+                         "AVERAGING_KERNEL", "PRIOR_PROFILE",
+                         "N_EDGES", "N_LAYERS"]
+            drop_vars = [v for v in drop_vars if v in sat_i.data_vars]
             satellite_columns.append(
-                sat_i.drop_vars(['PRESSURE_EDGES', 'PRESSURE_WEIGHT',
-                                 'AVERAGING_KERNEL', 'PRIOR_PROFILE',
-                                 'N_EDGES']))
+                sat_i.drop_vars(drop_vars)
+            )
 
         # Step up i
         i += config["LOCAL_SETTINGS"]["FILE_LENGTH_THRESHOLD"]
@@ -112,7 +113,7 @@ def apply_operator(config):#satellite_name, file_length_threshold=1e6):
          if date in util.get_gc_dates(model_conc_files)])
 
     # Get the satellite parser. 
-    read_satellite = util.get_satellite_parser(config)
+    read_satellite = parsers.get_satellite_parser(config)
 
     # Iterate through the satellite files:
     for sf in satellite_files:

--- a/operators.py
+++ b/operators.py
@@ -20,14 +20,19 @@ def apply_averaging_kernel(model_on_satellite_levels, satellite):
     return  model_column
 
 
-def get_model_columns(model, satellite, avker_center_or_edges,
-                      save_interpolation, save_dir):
+def get_model_columns(model, satellite, config, save_dir):
     """
     generic function to apply an operator to a satellite
     takes:
         - GEOS-Chem dataframe (not a problem b/c this is standard)
         - all required satellite inputs as np arrays
     """
+    satellite_name = config["LOCAL_SETTINGS"]["SATELLITE_NAME"]
+    avker_center_or_edges = config[satellite_name][
+        "AVERAGING_KERNEL_USES_CENTERS_OR_EDGES"
+    ]
+    save_interpolation = config["LOCAL_SETTINGS"]["SAVE_INTERPOLATION"]
+
     # Get the spatial and temporal indices linking each satellite observation
     # back to the model grid and apply them to the model data
     model = util.colocate_obs(model, satellite, save_dir)

--- a/operators.py
+++ b/operators.py
@@ -1,21 +1,27 @@
-import yaml
+import os
+
+os.environ['OPENBLAS_NUM_THREADS'] = '8'
+os.environ['MPI_NUM_THREADS'] = '8'
+os.environ['MKL_NUM_THREADS'] = '8'
+os.environ['OMP_NUM_THREADS'] = '8'
+
 import numpy as np
+import xarray as xr
 from interpolation import VerticalGrid
 import utilities as util
 
-with open("config.yaml", "r", encoding="utf8") as f:
-    config = yaml.safe_load(f)
-
 def apply_averaging_kernel(model_on_satellite_levels, satellite):
-    model_column = np.sum(satellite["PRESSURE_WEIGHT"]
-                          * (satellite["PRIOR_PROFILE"] 
-                             + satellite["AVERAGING_KERNEL"]
+    model_column = np.sum(satellite["PRESSURE_WEIGHT"].values[:, :, None]
+                          * (satellite["PRIOR_PROFILE"].values[:, :, None] 
+                             + satellite["AVERAGING_KERNEL"].values[:, :, None]
                              * (model_on_satellite_levels 
-                                - satellite["PRIOR_PROFILE"])),
+                                - satellite["PRIOR_PROFILE"].values[:, :, None])),
                                 axis=1)
     return  model_column
 
-def get_model_columns(model, satellite, satellite_name):
+
+def get_model_columns(model, satellite, avker_center_or_edges,
+                      save_interpolation, save_dir):
     """
     generic function to apply an operator to a satellite
     takes:
@@ -24,21 +30,28 @@ def get_model_columns(model, satellite, satellite_name):
     """
     # Get the spatial and temporal indices linking each satellite observation
     # back to the model grid and apply them to the model data
-    model = util.colocate_obs(model, satellite)
+    model = util.colocate_obs(model, satellite, save_dir)
 
     # Create an instance of the VerticalGrid class and interpolate the model
     # onto satellite levels
+    conc_vars = [
+        v for v in model.variables 
+        if v[:len("CONC_AT_PRESSURE_CENTERS")] == "CONC_AT_PRESSURE_CENTERS"]
+    # all_model_columns = xr.Dataset(coords={"N_OBS" : satellite["N_OBS"]})
     model_on_satellite_levels = VerticalGrid(
-        model["CONC_AT_PRESSURE_CENTERS"].values,
+        np.stack([model[v].values for v in conc_vars], axis=-1),
         model["PRESSURE_EDGES"].values,
         satellite["PRESSURE_EDGES"].values,
-        config[satellite_name]["AVERAGING_KERNEL_USES_CENTERS_OR_EDGES"])
+        avker_center_or_edges,
+        save_interpolation,
+        save_dir)
     model_on_satellite_levels = model_on_satellite_levels.interpolate()
 
     # Apply the averaging kernel
-    model_columns = apply_averaging_kernel(
-        model_on_satellite_levels, satellite)
-    
+    model_columns = apply_averaging_kernel(model_on_satellite_levels, satellite)
+    model_columns = xr.Dataset(
+        {v: (['N_OBS'], model_columns[:, i]) for i, v in enumerate(conc_vars)},
+        coords={'N_OBS': satellite["N_OBS"]})
     return model_columns
 
 

--- a/operators.py
+++ b/operators.py
@@ -1,10 +1,4 @@
 import os
-
-os.environ['OPENBLAS_NUM_THREADS'] = '8'
-os.environ['MPI_NUM_THREADS'] = '8'
-os.environ['MKL_NUM_THREADS'] = '8'
-os.environ['OMP_NUM_THREADS'] = '8'
-
 import numpy as np
 import xarray as xr
 from interpolation import VerticalGrid

--- a/parsers.py
+++ b/parsers.py
@@ -1,10 +1,42 @@
+import os
+
+os.environ['OPENBLAS_NUM_THREADS'] = '8'
+os.environ['MPI_NUM_THREADS'] = '8'
+os.environ['MKL_NUM_THREADS'] = '8'
+os.environ['OMP_NUM_THREADS'] = '8'
+
 import xarray as xr
 import numpy as np
+import re
+import time
 
 def _open_geoschem(file_path, variables):
-    preprocess = lambda ds : ds[variables]
-    return xr.open_mfdataset(file_path, preprocess=preprocess)
+    # Open the dataset
+    # data = xr.open_mfdataset(file_path, parallel=True)
+    data = []
+    for f in file_path:
+        data.append(xr.open_dataset(f).compute())
+    data = xr.merge(data)
 
+    # Now we get the variables we want, accounting for regex options. We also 
+    # save out a dictionary that will rename the variables as needed to the 
+    # standard names.
+    save_vars = {}
+    for default_name, var_pattern in variables.items():
+        # If the item looks like a regex (contains special characters like '*'), 
+        # treat it as regex
+        if re.search(r"[\*]", var_pattern):
+            save_vars.update(
+                {var : 
+                 f"{default_name}_{var.split(var_pattern.split('.*')[0])[-1]}" 
+                 for var in data.variables if re.match(var_pattern, var)})
+        else:
+            # If it's an exact match, check if it's in the dataset
+            if var_pattern in data.variables:
+                save_vars.update({var_pattern : default_name})
+
+    # Return the subsetted data
+    return data[save_vars.keys()].rename(save_vars)
 
 def read_geoschem_file(file_path_conc, file_path_edges, data_fields):
     '''
@@ -14,6 +46,8 @@ def read_geoschem_file(file_path_conc, file_path_edges, data_fields):
         # use gcpy function for reading GEOS-Chem files, may need to wrap
     '''
     # Define the variables that should be maintained when opening the files
+    ## For concentration files, keep everything except PRESSURE_EDGES. Also,
+    ## 
     conc_vars = dict(data_fields)
     del conc_vars["PRESSURE_EDGES"]
 
@@ -21,12 +55,9 @@ def read_geoschem_file(file_path_conc, file_path_edges, data_fields):
     del edge_vars["CONC_AT_PRESSURE_CENTERS"]
 
     # Open and combine edge and concentration files
-    gc = xr.merge([_open_geoschem(file_path_conc, list(conc_vars.values())),
-                   _open_geoschem(file_path_edges, list(edge_vars.values()))])
-
-    # Rename the fields to the standard (as defined in config.yaml)
-    rename_fields = {v : k for k, v in data_fields.items()}
-    gc = gc.rename(rename_fields)
+    print('Merging model data : ', time.time())
+    gc = xr.merge([_open_geoschem(file_path_conc, conc_vars),
+                   _open_geoschem(file_path_edges, edge_vars)])
 
     # Transpose
     gc = gc.transpose("TIME", "LONGITUDE", "LATITUDE", "LEV", "ILEV")
@@ -84,6 +115,10 @@ def read_OCO2_v11_1_preprocessed(file_path, data_fields):
     satellite["PRIOR_PROFILE"] *= 1e-6
     satellite["SATELLITE_COLUMN"] *= 1e-6
 
+    # Filter (we will comment this out for the final round of iterations)
+    satellite = satellite.compute()
+# # # # # #     satellite = satellite.where(satellite["type_flag"] < 2, drop=True)
+    
     return satellite
 
 

--- a/parsers.py
+++ b/parsers.py
@@ -37,6 +37,7 @@ def _open_geoschem(file_path, variables):
     # Return the subsetted data
     return data[save_vars.keys()].rename(save_vars)
 
+
 def read_geoschem_file(file_path_conc, file_path_edges, data_fields):
     '''
     Eventually, this should be switched to a gcpy function. 
@@ -46,7 +47,7 @@ def read_geoschem_file(file_path_conc, file_path_edges, data_fields):
     '''
     # Define the variables that should be maintained when opening the files
     ## For concentration files, keep everything except PRESSURE_EDGES. Also,
-    ## 
+    ## get rid of CONC_AT_PRESSURE_CENTERS for edge files.
     conc_vars = dict(data_fields)
     del conc_vars["PRESSURE_EDGES"]
 
@@ -81,23 +82,52 @@ def read_satellite_file(file_path, data_fields):
     # Open the file (and remove subsetting because we want to keep variables)
     satellite = xr.open_dataset(file_path)
 
-    # Rename satellite dimension names to the standard (as defined in 
-    # config.yaml)
+    # Rename satellite dimension names to the standard from config.yaml
     rename_fields = {v : k for k, v in data_fields.items()}
     satellite = satellite.rename(rename_fields)
 
     # Return the data
     return satellite
 
-def read_TROPOMI_vXX_science(file_path, data_fields):
-    # read TROPOMI file
-    # grab tropomi data columns specified in config and rename them to 
-    # standard naming
-    # First pass of a TROPOMI science product parser (without using any 
-    # TROPOMI data)
+def read_TROPOMI(file_path, data_fields):
+    # Remove quality_flag if it isn't present in the fields
+    data_fields = {k : v for k, v in data_fields.items() if v.lower() != 'none'}
+
+    satellite = xr.open_dataset(file_path)
+
+
+    # Correct units from molecules/cm2 to mol/m2
+    satellite['ch4_profile_apriori'] *= 1e4/6.02214e23
+    satellite['dry_air_subcolumns'] *= 1e4/6.02214e23
+
+
+    # d = xr.open_dataset(file, group='diagnostics')    
 
     pass
 
+
+def read_TROPOMI_blended(file_path, data_fields):
+    # Remove none fields
+    data_fields = {k : v for k, v in data_fields.items() if v.lower() != 'none'}
+
+    # Open the satellite file. The blended data has all fields in one group.
+    satellite = xr.open_dataset(file_path)
+
+    # Rename satellite dimension names to the standard from config.yaml)
+    rename_fields = {v : k for k, v in data_fields.items()}
+    satellite = satellite.rename(rename_fields)
+
+    # Get the pressure edges (Pa) based on the TROPOMI surface and pressure 
+    # intervals. The pressure array is from TOA for consistency with other 
+    # TROPOMI objects.
+    z = satellite.layer.size
+    p_surface = satellite['surface_pressure'].values.reshape((-1, 1))
+    p_interval = satellite['pressure_interval'].values.reshape((-1, 1))
+    p_edges = p_surface - np.arange(z + 1).reshape((1, -1))*p_interval
+    p_edges = xr.DataArray(p_edges[:, ::-1], dims=['N_OBS', 'N_EDGES'])
+    satellite = satellite.assign(PRESSURE_EDGES=p_edges)
+
+    return satellite
 
 def read_GOSAT_vXX(file_path, data_fields):
     # read GOSAT file

--- a/parsers.py
+++ b/parsers.py
@@ -1,13 +1,16 @@
 import os
 
-os.environ['OPENBLAS_NUM_THREADS'] = '8'
-os.environ['MPI_NUM_THREADS'] = '8'
-os.environ['MKL_NUM_THREADS'] = '8'
-os.environ['OMP_NUM_THREADS'] = '8'
+os.environ["OPENBLAS_NUM_THREADS"] = "8"
+os.environ["MPI_NUM_THREADS"] = "8"
+os.environ["MKL_NUM_THREADS"] = "8"
+os.environ["OMP_NUM_THREADS"] = "8"
 
 import xarray as xr
 import numpy as np
+import pandas as pd
 import re
+import inspect
+from interpolation import VerticalGrid
 
 def _open_geoschem(file_path, variables):
     # Open the dataset
@@ -15,22 +18,22 @@ def _open_geoschem(file_path, variables):
     data = []
     for f in file_path:
         data.append(xr.open_dataset(f).compute())
-    data = xr.merge(data)
+    data = xr.concat(data, dim="time", data_vars="all")
 
     # Now we get the variables we want, accounting for regex options. We also 
     # save out a dictionary that will rename the variables as needed to the 
     # standard names.
     save_vars = {}
     for default_name, var_pattern in variables.items():
-        # If the item looks like a regex (contains special characters like '*'), 
+        # If the item looks like a regex (contains special characters like "*"), 
         # treat it as regex
         if re.search(r"[\*]", var_pattern):
             save_vars.update(
                 {var : 
-                 f"{default_name}_{var.split(var_pattern.split('.*')[0])[-1]}" 
+                 f"{default_name}_{var.split(var_pattern.split(".*")[0])[-1]}" 
                  for var in data.variables if re.match(var_pattern, var)})
         else:
-            # If it's an exact match, check if it's in the dataset
+            # If it"s an exact match, check if it"s in the dataset
             if var_pattern in data.variables:
                 save_vars.update({var_pattern : default_name})
 
@@ -76,8 +79,8 @@ def read_satellite_file(file_path, data_fields):
     may require filtering along multiple criteria. Please write your own 
     parser in these cases.
     '''
-    # Remove quality_flag if it isn't present in the fields
-    data_fields = {k : v for k, v in data_fields.items() if v.lower() != 'none'}
+    # Remove quality_flag if it isn"t present in the fields
+    data_fields = {k : v for k, v in data_fields.items() if v.lower() != "none"}
 
     # Open the file (and remove subsetting because we want to keep variables)
     satellite = xr.open_dataset(file_path)
@@ -89,45 +92,260 @@ def read_satellite_file(file_path, data_fields):
     # Return the data
     return satellite
 
+def read_TCCON_MIP(file_path, data_fields):
+    tccon = xr.open_dataset(file_path, group="CO2")
+
+    rename_fields = {v : k for k, v in data_fields.items()
+                     if v != "none"}
+    tccon = tccon.rename(rename_fields)
+
+    # First, drop unneeded variables
+    tccon = tccon.drop_vars(["prior_h2o",
+                             "sza",
+                             "prior_mixing_tccon",
+                             "public"])
+
+    # Then, adjust the units of TCCON to match GEOS-Chem
+    ## Pa to hPa
+    for var in ["p_surf", "p_levels_prior", "p_levels_ak"]:
+        tccon[var] *= 1e-2
+    ## ppm to mol/mol (dry)
+    for var in ["PRIOR_PROFILE", "SATELLITE_COLUMN", "sigma_column_mixing"]:
+        tccon[var] *= 1e-6
+
+    # Process the time to be a reasonable format
+    time = pd.DataFrame({
+        "year" : tccon["TIME"].isel(idate=0),
+        "month" : tccon["TIME"].isel(idate=1),
+        "day" : tccon["TIME"].isel(idate=2),
+        "hour" : tccon["TIME"].isel(idate=3),
+        "minute" : tccon["TIME"].isel(idate=4),
+        "second" : tccon["TIME"].isel(idate=5)
+    })
+    tccon["TIME"] = xr.DataArray(pd.to_datetime(time).values, 
+                                 dims=["N_OBS"], 
+                                 coords={"N_OBS" : tccon.coords["N_OBS"]})
+    tccon = tccon.drop_vars(["solar_time_bin"])
+
+    # The averaging kernel is defined on the fixed pressure grid p_levels_ak.
+    # We cut off everything at the TCCON surface pressure.
+    pressure = tccon["p_levels_ak"].expand_dims(N_OBS=tccon.sizes["N_OBS"])
+
+    # Deal with the case where the pressure grid is fully above the surface
+    # pressure. We replace the bottom level with the surface pressure.
+    p0 = pressure.isel(N_EDGES=0)
+    p0 = p0.where(p0 >= tccon["p_surf"], tccon["p_surf"])
+    pressure = xr.where(
+        pressure["N_EDGES"] == pressure["N_EDGES"][0],
+        p0,
+        pressure
+    )
+
+    # Truncate the dataset to only be above the TCCON surface. Fill in the 
+    # first nan value with p_surf.
+    pressure = pressure.where(pressure <= tccon["p_surf"])
+    edge_index = xr.DataArray(np.arange(pressure.sizes["N_EDGES"]), 
+                              dims="N_EDGES")
+    replace_mask = (edge_index == (pressure.notnull().argmax("N_EDGES") - 1))
+    pressure = xr.where(replace_mask, tccon["p_surf"], pressure)
+    
+    # Now, shift any variables that are on the N_OBS x N_EDGES grid so that
+    # the surface is the first 
+    shift_grid = lambda var, fill_zero : xr.apply_ufunc(
+        shift_tccon_pressure_grid,
+        var,
+        kwargs={"fill_zero": fill_zero},
+        input_core_dims=[["N_EDGES"]],
+        output_core_dims=[["N_EDGES"]],
+        vectorize=True
+    )
+    for name, var in tccon.data_vars.items():
+        if ("N_EDGES" in var.dims) & ("N_OBS" in var.dims):
+            # Truncate the dataset to only be above the TCCON surface
+            print(name)
+            var = var.where(~pressure.isnull())
+
+            # Shift so that the first level is first
+            tccon[name] = shift_grid(var, True)
+    
+    # And finally shift the pressure variable
+    pressure = shift_grid(pressure, False)
+
+    # Save out the pressure edges in hPa
+    tccon["PRESSURE_EDGES"] = pressure
+    
+    # Define the pressure weights. Note that tccon["p_surf"] and the first level
+    # of pressure should be the same.
+    pressure_weight = - pressure.diff(dim="N_EDGES") / tccon["p_surf"]
+    pressure_weight = pressure_weight.rename({'N_EDGES' : 'N_CENTERS'})
+    tccon["PRESSURE_WEIGHT"] = pressure_weight
+
+    # We are now working on a pressure center grid. We need to interpolate
+    # the prior and the averaging kernel onto this grid.
+
+    # First, the prior. This is currently defined on p_levels_prior, which is
+    # different from the pressure grid (based on p_levels_ak). First, we 
+    # very simply interpolate to pressure centers, then we use Vertical Grid 
+    # to interpolate to the new grid.
+    prior_profile_centers = (
+        tccon["PRIOR_PROFILE"].isel(N_EDGES=slice(None, -1)) + 
+        tccon["PRIOR_PROFILE"].isel(N_EDGES=slice(1, None))
+    ) / 2
+    prior_profile_on_new_grid = VerticalGrid(
+        np.stack([prior_profile_centers.values], axis=-1), # The values to regrid
+        tccon["p_levels_prior"].values, # The original grid
+        tccon["PRESSURE_EDGES"].values, # The target grid
+        "centers", 
+        save_interpolation="False", 
+        save_dir=None, 
+        expand_model_edges=False
+    ).interpolate()
+    tccon["PRIOR_PROFILE"] = xr.DataArray(
+        prior_profile_on_new_grid[:, :, 0], 
+        dims=["N_OBS", "N_CENTERS"],
+    )
+
+    # Finally, we need to interpolate the averaging kernel to the pressure 
+    # centers. Because our PRESSURE_EDGES are based on the p_levels_ak,
+    # this is much simpler.
+    ak_centers = (
+        tccon["AVERAGING_KERNEL"].isel(N_EDGES=slice(None, -1)) + 
+        tccon["AVERAGING_KERNEL"].isel(N_EDGES=slice(1, None))
+    ) / 2
+    p_levels_ak = tccon["p_levels_ak"].expand_dims(N_OBS=tccon.sizes["N_OBS"])
+    ak_on_new_grid = VerticalGrid(
+        np.stack([ak_centers.values], axis=-1), # The values to regrid
+        p_levels_ak.values, # The original grid
+        tccon["PRESSURE_EDGES"].values, # The target grid
+        "centers", 
+        save_interpolation="False", 
+        save_dir=None,
+        expand_model_edges=False
+    ).interpolate()
+    tccon["AVERAGING_KERNEL"] = xr.DataArray(
+        ak_on_new_grid[:, :, 0], 
+        dims=["N_OBS", "N_CENTERS"],
+    )
+
+    # Now, remove superfluous pressure information
+    tccon = tccon.drop_vars(["p_levels_prior", "p_levels_ak"])
+
+    return tccon
+
+def shift_tccon_pressure_grid(row, fill_zero=True):
+    # Count leading NaNs in reference
+    isnan = np.isnan(row)
+
+    if np.all(isnan):
+        return row  # nothing sensible to shift
+
+    # Get the fill value
+    if fill_zero:
+        fill_value = 0
+    else:
+        fill_value = row[~isnan][-1]  # last non-NaN value
+    
+    shift = max(np.argmax(~isnan), 0)
+
+    if shift == 0:
+        return row
+
+    return np.concatenate([
+        row[shift:],                     # shift left
+        np.full(shift, fill_value)       # pad end
+    ])
+
+
 def read_TROPOMI(file_path, data_fields):
-    # Remove quality_flag if it isn't present in the fields
-    data_fields = {k : v for k, v in data_fields.items() if v.lower() != 'none'}
+    # Define where each of the needed variables are found
+    group_to_vars = {
+        "PRODUCT/" : [
+            "latitude",
+            "longitude",
+            "methane_mixing_ratio_bias_corrected",
+            "qa_value",
+            "time_utc",
+        ],
+        "PRODUCT/SUPPORT_DATA/DETAILED_RESULTS" : [
+            "surface_albedo_SWIR",
+            "surface_albedo_NIR",
+            "column_averaging_kernel",
+        ],
+        "PRODUCT/SUPPORT_DATA/INPUT_DATA" : [
+            "surface_altitude",
+            "surface_pressure",
+            "pressure_interval",
+            "methane_profile_apriori",
+            "dry_air_subcolumns",
+            "surface_classification",
+        ],
+        # "PRODUCT/SUPPORT_DATA/GEOLOCATIONS" : [
+        #     "longitude_bounds",
+        #     "latitude_bounds",
+        # ] # HN: Not supported yet
+    }
 
-    satellite = xr.open_dataset(file_path)
-
-
-    # Correct units from molecules/cm2 to mol/m2
-    satellite['ch4_profile_apriori'] *= 1e4/6.02214e23
-    satellite['dry_air_subcolumns'] *= 1e4/6.02214e23
-
-
-    # d = xr.open_dataset(file, group='diagnostics')    
-
-    pass
-
-
-def read_TROPOMI_blended(file_path, data_fields):
-    # Remove none fields
-    data_fields = {k : v for k, v in data_fields.items() if v.lower() != 'none'}
-
-    # Open the satellite file. The blended data has all fields in one group.
-    satellite = xr.open_dataset(file_path)
+    # Open the data
+    satellite = []
+    for group, vars in group_to_vars.items():
+        satellite.append(xr.open_dataset(file_path, group=group)[vars])
+    satellite = xr.merge(satellite)
 
     # Rename satellite dimension names to the standard from config.yaml)
-    rename_fields = {v : k for k, v in data_fields.items()}
+    rename_fields = {v : k for k, v in data_fields.items()
+                     if v.lower() != "none"}
     satellite = satellite.rename(rename_fields)
 
-    # Get the pressure edges (Pa) based on the TROPOMI surface and pressure 
-    # intervals. The pressure array is from TOA for consistency with other 
-    # TROPOMI objects.
-    z = satellite.layer.size
-    p_surface = satellite['surface_pressure'].values.reshape((-1, 1))
-    p_interval = satellite['pressure_interval'].values.reshape((-1, 1))
-    p_edges = p_surface - np.arange(z + 1).reshape((1, -1))*p_interval
-    p_edges = xr.DataArray(p_edges[:, ::-1], dims=['N_OBS', 'N_EDGES'])
-    satellite = satellite.assign(PRESSURE_EDGES=p_edges)
+    # Collapse the scanline x groundpixel dimensions into nobs. We also get rid
+    # of the time variable and move the latitude/longitude coordinates into 
+    # the variables. Finally, we drop nans.
+    satellite = satellite.squeeze(drop=True)
+    satellite = satellite.stack(N_OBS=("scanline", "ground_pixel"))
+    satellite = satellite.reset_index("N_OBS", drop=True)
+    satellite = satellite.reset_coords(["LATITUDE", "LONGITUDE"])
+    satellite = satellite.where(~satellite["SATELLITE_COLUMN"].isnull(),
+                                drop=True)
+
+    # Convert the satellite column from ppb to mol/mol (GEOS-Chem base units)
+    satellite["SATELLITE_COLUMN"] *= 1e-9 
+
+    # The prior and the dry_air_subcolumns are both in mol/m2. We use 
+    # dry_air_subcolumns to convert the prior to mol/mol
+    satellite["PRIOR_PROFILE"] = (satellite["PRIOR_PROFILE"] / 
+                                  satellite["dry_air_subcolumns"])
+
+    # Handle pressure
+    z = xr.DataArray(np.arange(satellite["N_CENTERS"].shape[0] + 1)[::-1],
+                     dims="N_EDGES")                     
+    satellite["PRESSURE_EDGES"] = (
+        satellite["surface_pressure"] - z*satellite["pressure_interval"]
+    ) / 100 # convert to hPa
+    satellite = satellite.drop_vars(["surface_pressure", "pressure_interval"])
+
+    # Calculate the pressure weights
+    satellite["PRESSURE_WEIGHT"] = (
+        satellite["dry_air_subcolumns"] / 
+        satellite["dry_air_subcolumns"].sum(dim="N_CENTERS")
+    )
+    satellite = satellite.drop_vars(["dry_air_subcolumns"])
+
+    # Process the time variable
+    satellite["TIME"] = xr.DataArray(
+        [t.replace("Z", "") for t in satellite["TIME"].values],
+        coords=satellite["TIME"].coords,
+        dims=satellite["TIME"].dims).astype("datetime64[ns]"
+    )
+
+    # Define the blended albedo 
+    satellite["blended_albedo"] = (
+        2.4 * satellite["surface_albedo_NIR"] - 
+        1.13 * satellite["surface_albedo_SWIR"])
+
+    # TODO: Handle QA masking? 
+    # TODO: I'm also currently not handling the surface classification variable
 
     return satellite
+
 
 def read_GOSAT_vXX(file_path, data_fields):
     # read GOSAT file
@@ -145,20 +363,62 @@ def read_OCO2_v11_1_preprocessed(file_path, data_fields):
 
     # Filter (we will comment this out for the final round of iterations)
     satellite = satellite.compute()
-    satellite = satellite.where(satellite["type_flag"] < 2, drop=True)
+    # satellite = satellite.where(satellite["type_flag"] < 2, drop=True)
 
     return satellite
 
 
 def check_satellite_data(satellite):
-    # TO DO: assert type(sat["TIME"]) == datetime (need to deal with the fact
-    # that dtype shows up as '<M8[ns]' or '>M8[ns]' depending on the endianess
+    # TODO: assert type(sat["TIME"]) == datetime (need to deal with the fact
+    # that dtype shows up as "<M8[ns]" or ">M8[ns]" depending on the endianess
     # ?? of the system)
-        # Ensure that satellite pressure levels are in descending order:
-    if np.all(np.diff(satellite["PRESSURE_EDGES"]) > 0):
-        print("  Switching direction of N_EDGES.")
-        satellite = satellite.reindex(
-            N_EDGES=list(reversed(satellite["N_EDGES"]))
+    # Ensure that satellite pressure levels are in descending order:
+    if np.all(np.diff(satellite["PRESSURE_EDGES"]) >= 0):
+        print("  Switching direction of N_EDGES/N_CENTERS.")
+        # Identify which flip dims actually exist in this dataset, then flip them
+        dims_to_flip = {"N_CENTERS", "N_EDGES"}
+        active_flip_dims = dims_to_flip & set(satellite.dims)
+        satellite = satellite.isel(
+            {dim: slice(None, None, -1) for dim in active_flip_dims}
         )
+        
+    # Ensure that the satellite data has the correct ordering of dimensions
+    satellite = satellite.transpose("N_OBS", ...)
 
     return satellite
+
+
+def get_satellite_parser(config):
+    # Get the function that opens the satellite data. Check that the function
+    # has a default value for satellite_name. If not, use satellite_name
+    satellite_name = config["LOCAL_SETTINGS"]["SATELLITE_NAME"]
+    read_sat = globals()[config[satellite_name]["PARSER"]]
+    name_param = inspect.signature(read_sat).parameters["data_fields"]
+    if name_param.default is not name_param.empty:
+        satellite_name = name_param.default
+    print(f"satellite_name : {satellite_name}")
+    print(f"parser : {config[satellite_name]['PARSER']}")
+
+    # Define the function
+    def read_satellite(file_path):
+        dataset = read_sat(file_path, config[satellite_name]["DATA_FIELDS"])
+        dataset = check_satellite_data(dataset)
+        return dataset
+    
+    return read_satellite
+
+
+# def reverse_center_edge_vars(ds: xr.Dataset) -> xr.Dataset:
+#     """
+#     Reverse (flip) all variables that have an N_CENTERS or N_EDGES dimension.
+#     Coordinate values along those dimensions are also reversed if present.
+#     """
+#     dims_to_flip = {"N_CENTERS", "N_EDGES"}
+    
+#     # Identify which flip dims actually exist in this dataset
+#     active_flip_dims = dims_to_flip & set(ds.dims)
+    
+#     if not active_flip_dims:
+#         return ds  # Nothing to do
+    
+#     return ds.isel({dim: slice(None, None, -1) for dim in active_flip_dims})

--- a/parsers.py
+++ b/parsers.py
@@ -1,10 +1,4 @@
 import os
-
-os.environ["OPENBLAS_NUM_THREADS"] = "8"
-os.environ["MPI_NUM_THREADS"] = "8"
-os.environ["MKL_NUM_THREADS"] = "8"
-os.environ["OMP_NUM_THREADS"] = "8"
-
 import xarray as xr
 import numpy as np
 import pandas as pd

--- a/parsers.py
+++ b/parsers.py
@@ -8,7 +8,6 @@ os.environ['OMP_NUM_THREADS'] = '8'
 import xarray as xr
 import numpy as np
 import re
-import time
 
 def _open_geoschem(file_path, variables):
     # Open the dataset
@@ -55,7 +54,6 @@ def read_geoschem_file(file_path_conc, file_path_edges, data_fields):
     del edge_vars["CONC_AT_PRESSURE_CENTERS"]
 
     # Open and combine edge and concentration files
-    print('Merging model data : ', time.time())
     gc = xr.merge([_open_geoschem(file_path_conc, conc_vars),
                    _open_geoschem(file_path_edges, edge_vars)])
 
@@ -117,8 +115,8 @@ def read_OCO2_v11_1_preprocessed(file_path, data_fields):
 
     # Filter (we will comment this out for the final round of iterations)
     satellite = satellite.compute()
-# # # # # #     satellite = satellite.where(satellite["type_flag"] < 2, drop=True)
-    
+    satellite = satellite.where(satellite["type_flag"] < 2, drop=True)
+
     return satellite
 
 

--- a/utilities.py
+++ b/utilities.py
@@ -6,10 +6,8 @@ os.environ['MKL_NUM_THREADS'] = '8'
 os.environ['OMP_NUM_THREADS'] = '8'
 
 import glob
-import inspect
 import numpy as np
 import xarray as xr
-import parsers
 
 def get_file_lists(local_config):
     '''
@@ -32,7 +30,7 @@ def get_file_lists(local_config):
     # Require that all of these lists contain files.
     if len(sat_files) == 0:
         print(f"Satellite directory: "
-              f"{local_config['OBS_DIR']}/{local_config['FILE_NAME_FORMAT']}")
+              f"{local_config['OBS_DIR']}/{local_config['OBS_FILE_FORMAT']}")
         raise ValueError("Satellite files are empty.")
     
     if len(model_edge_files) == 0:
@@ -80,25 +78,6 @@ def get_gc_dates(file_names):
 def get_gc_files_for_dates(file_names, dates):
     return file_names[np.in1d(get_gc_dates(file_names), dates)]
 
-
-def get_satellite_parser(config):
-    # Get the function that opens the satellite data. Check that the function
-    # has a default value for satellite_name. If not, use satellite_name
-    satellite_name = config["LOCAL_SETTINGS"]["SATELLITE_NAME"]
-    read_sat = getattr(parsers, config[satellite_name]["PARSER"])
-    name_param = inspect.signature(read_sat).parameters["data_fields"]
-    if name_param.default is not name_param.empty:
-        satellite_name = name_param.default
-    print(f"satellite_name : {satellite_name}")
-    print(f"parser : {config[satellite_name]['PARSER']}")
-
-    # Define the function
-    def read_satellite(file_path):
-        dataset = read_sat(file_path, config[satellite_name]["DATA_FIELDS"])
-        dataset = parsers.check_satellite_data(dataset)
-        return dataset
-    
-    return read_satellite
 
 def get_missing_times(satellite_times, model_times):
     satellite_times = satellite_times.dt.strftime("%Y-%m-%d.%H")

--- a/utilities.py
+++ b/utilities.py
@@ -1,10 +1,4 @@
 import os
-
-os.environ['OPENBLAS_NUM_THREADS'] = '8'
-os.environ['MPI_NUM_THREADS'] = '8'
-os.environ['MKL_NUM_THREADS'] = '8'
-os.environ['OMP_NUM_THREADS'] = '8'
-
 import glob
 import numpy as np
 import xarray as xr

--- a/utilities.py
+++ b/utilities.py
@@ -1,3 +1,10 @@
+import os
+
+os.environ['OPENBLAS_NUM_THREADS'] = '8'
+os.environ['MPI_NUM_THREADS'] = '8'
+os.environ['MKL_NUM_THREADS'] = '8'
+os.environ['OMP_NUM_THREADS'] = '8'
+
 import glob
 import inspect
 import numpy as np
@@ -13,11 +20,12 @@ def get_file_lists(local_config):
     sat_files = f"{local_config['OBS_DIR']}/{local_config['OBS_FILE_FORMAT']}"
     sat_files = np.array(sorted(glob.glob(sat_files)))    
 
-    model_edge_files = (f"{local_config['MODEL_DIR']}/"
+
+    model_edge_files = (f"{local_config['MODEL_LEVEL_EDGE_DIR']}/"
                      f"{local_config['LEVEL_EDGE_FILE_FORMAT']}")
     model_edge_files = np.array(sorted(glob.glob(model_edge_files)))
 
-    model_conc_files = (f"{local_config['MODEL_DIR']}/"
+    model_conc_files = (f"{local_config['MODEL_CONCENTRATION_DIR']}/"
                         f"{local_config['CONCENTRATION_FILE_FORMAT']}")
     model_conc_files = np.array(sorted(glob.glob(model_conc_files)))
 
@@ -29,13 +37,13 @@ def get_file_lists(local_config):
     
     if len(model_edge_files) == 0:
         print(f"Model edge directory: "
-              f"{local_config['MODEL_DIR']}/"
+              f"{local_config['MODEL_LEVEL_EDGE_DIR']}/"
               f"{local_config['LEVEL_EDGE_FILE_FORMAT']}")
         raise ValueError("Model edge files are empty.")
     
     if len(model_conc_files) == 0:
         print(f"Model concentration directory: "
-              f"{local_config['MODEL_DIR']}/"
+              f"{local_config['MODEL_CONCENTRATION_DIR']}/"
               f"{local_config['CONCENTRATION_FILE_FORMAT']}")
         raise ValueError("Model concentration files are empty.")
     
@@ -104,7 +112,7 @@ def get_missing_times(satellite_times, model_times):
     return missing_times
 
 
-def colocate_obs(model, satellite):
+def colocate_obs(model, satellite, save_dir=None):
     """
     directly from Hannah's code
     get gridcells which are coincident with each satellite observation
@@ -112,26 +120,40 @@ def colocate_obs(model, satellite):
     fast implementation, credit Nick
     TO DO : This could be sped up using Nick's implementation, but that
     requires knowledge of the latitude and longitude delta
-    """    
-    # Now get indices, beginning with time
-    time_idx = np.where(satellite["TIME"].dt.strftime("%Y-%m-%d.%H") 
-                        == model["TIME"].dt.strftime("%Y-%m-%d.%H"))
-    if len(time_idx) == 2:
-        time_idx = time_idx[1]
-    elif len(time_idx) == 1:
-        time_idx = time_idx[0]
-    else:
-        raise ValueError('Time index is not recognized.')
-    time_idx = xr.DataArray(time_idx, dims="N_OBS")
+    """
+    # We need to get indices in time and space (lat/lon). We begin by trying to
+    # load these indices, because for Jacobian simulations, it can save time.
+    # If this fails, we will calculate them.
+    try:
+        idx = xr.open_dataset(f'{save_dir}_idx.nc')
+        print("  Using pre-computed time and space indices.")
+    except:
+        print("  Computing time and space indices.")
+        # Now get indices, beginning with time
+        time_idx = np.where(satellite["TIME"].dt.strftime("%Y-%m-%d.%H") 
+                            == model["TIME"].dt.strftime("%Y-%m-%d.%H"))
+        if len(time_idx) == 2:
+            time_idx = time_idx[1]
+        elif len(time_idx) == 1:
+            time_idx = time_idx[0]
+        else:
+            raise ValueError('Time index is not recognized.')
+        time_idx = xr.DataArray(time_idx, dims="N_OBS")
 
-    # Longitude and latitude index
-    lon_idx = get_closest_index(model["LONGITUDE"].values, 
-                                satellite["LONGITUDE"].values)
-    lat_idx = get_closest_index(model["LATITUDE"].values, 
-                                satellite["LATITUDE"].values)
+        # Longitude and latitude index
+        lon_idx = get_closest_index(model["LONGITUDE"].values, 
+                                    satellite["LONGITUDE"].values)
+        lat_idx = get_closest_index(model["LATITUDE"].values, 
+                                    satellite["LATITUDE"].values)
+        
+        idx = xr.Dataset({"lat" : lat_idx, "lon" : lon_idx, "time" : time_idx})
+        
+        # Save out
+        idx.to_netcdf(f"{save_dir}_idx.nc")
 
     # Subset the data
-    model = model.isel(TIME=time_idx, LONGITUDE=lon_idx, LATITUDE=lat_idx)
+    model = model.isel(TIME=idx['time'], 
+                       LONGITUDE=idx['lon'], LATITUDE=idx['lat'])
 
     return model
 


### PR DESCRIPTION
There are a series of changes in this pull request, though most of them center around improved efficiency for the use case of applying GOOPy to Jacobian simulations (for application in the IMI). In these simulations, GEOS-Chem is run 100+ times with slightly different fluxes and the atmosphere is sampled in the same way in each simulation. They also often use multiple tracers (e.g., CH4_0001, CH4_0002) within one simulation for computational improvement.  This pull request includes supporting changes, mostly in two categories: 

1. We now allow some of the key outputs of the operator (the interpolation matrices and space-time mapping indices) to be pre-generated. We add a config option SAVE_INTERPOLATION accordingly. If this is true, the operator will save these files out in the observation directory (in a sub directory called "operator_components"). These files can be large. If this is false, the operator will not save these files out. In both cases, the operator will attempt to load these files. If it finds the files, it will use them. If not, it will re-calculate it. In practice, this means that for standard (non-Jacobian) applications, SAVE_INTERPOLATION should be False. For Jacobian applications, SAVE_INTERPOLATION will be True for the prior simulation and False for subsequent simulations.

2. We modify the assumption that the GEOS-Chem files only have one species of interest. This requires changing the parsers for GEOS-Chem and the assumed dimensions of the interpolation operators, etc.